### PR TITLE
Add fallback configuration for fostgres.sql view

### DIFF
--- a/Cpp/fostgres/Fostgres-sql-view.md
+++ b/Cpp/fostgres/Fostgres-sql-view.md
@@ -5,9 +5,6 @@
 
 ## Configuration
 
-* `response` -- The type of API. The URL to database mapping essentially must describe a resource that comprised either one or multiple rows in the relation/table.
-    * `object` -- The URL describes a single row in the database.
-    * `csj` (default) -- The URL describes multiple rows in the database.
 * `sql` -- The individual end points, see "End point configuration" below.
 
 The view first goes through the list of end point configurations looking for the first path match.
@@ -17,6 +14,9 @@ The view first goes through the list of end point configurations looking for the
 
 Each end point configuration consists of a number of keys:
 
+* `response` -- The type of API. The URL to database mapping essentially must describe a resource that comprised either one or multiple rows in the relation/table.
+    * `object` -- The URL describes a single row in the database.
+    * `csj` (default) -- The URL describes multiple rows in the database.
 * `path` -- The path configuration to match against
 * `GET` -- Used for `GET` requests.
 * `PUT` -- Used for `PUT` requests.


### PR DESCRIPTION
This will allow the user to configure a fallback view for use when none of the path matches are selected.