### PR TITLE
Csj parse error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2020-04-22  Kirit Saelensminde  <kirit@felspar.com>
  * CSJ parsing now throws a proper `parse_error`
+ * Special case `parse_error` to map to 400 responses when expected in fg tests.
 
 2019-08-21  Kirit Saelensminde  <kirit@felspar.com>
  Improve the display of test failures from `fostgres-test`.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-04-22  Kirit Saelensminde  <kirit@felspar.com>
+ * CSJ parsing now throws a proper `parse_error`
+
 2019-08-21  Kirit Saelensminde  <kirit@felspar.com>
  Improve the display of test failures from `fostgres-test`.
 
@@ -13,7 +16,7 @@
 
 2019-06-24  Pumidon Phathong  <pumidon@hot-now.com>
  GET requests that don't check the body content now return the response body.
- 
+
 2019-06-14  Kirit Saelensminde  <kirit@felspar.com>
  Object APIs can now process JSON arrays into a separate table.
 

--- a/Cpp/fost-csj/parser.cpp
+++ b/Cpp/fost-csj/parser.cpp
@@ -73,8 +73,7 @@ fostlib::csj::parser::const_iterator &
         while (pos != owner.li_end) {
             parseline(owner.line_p, ++pos, owner.li_end, line);
             if (line.size()) {
-                throw exceptions::not_implemented(
-                        __func__, "Empty line embedded in CSJ file");
+                throw exceptions::parse_error{"Empty line embedded in CSJ file"};
             }
         }
     } else if (line.size() != owner.header().size()) {

--- a/Cpp/fost-csj/parser.cpp
+++ b/Cpp/fost-csj/parser.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2016-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2016-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -8,6 +8,7 @@
 
 #include <fost/csj.parser.hpp>
 #include <fost/insert>
+#include <fost/exception/parse_error.hpp>
 
 
 namespace {
@@ -20,15 +21,14 @@ namespace {
             if (not boost::spirit::qi::parse(
                         line_pos.first, line_pos.second, parser, into)
                 || line_pos.first != line_pos.second) {
-                throw fostlib::exceptions::not_implemented(
-                        __func__, "Could not parse row", *pos);
+                throw fostlib::exceptions::parse_error{"Could not parse row", *pos};
             }
         }
     }
 }
 
 
-/*
+/**
     fostlib::cjs::parser
 */
 
@@ -39,8 +39,7 @@ fostlib::csj::parser::parser(f5::u8view str)
   li_end(line_iter.end()) {
     parseline(headers_p, li_pos, li_end, headers);
     if (not headers.size()) {
-        throw exceptions::not_implemented(
-                __func__, "No headers were found when parsing CSJ");
+        throw exceptions::parse_error{"No headers were found when parsing CSJ"};
     }
     ++li_pos;
 }
@@ -54,7 +53,7 @@ fostlib::csj::parser::const_iterator fostlib::csj::parser::end() const {
 }
 
 
-/*
+/**
     fostlib::csj::parser::const_iterator
 */
 

--- a/Cpp/fost-csj/parser.cpp
+++ b/Cpp/fost-csj/parser.cpp
@@ -21,7 +21,8 @@ namespace {
             if (not boost::spirit::qi::parse(
                         line_pos.first, line_pos.second, parser, into)
                 || line_pos.first != line_pos.second) {
-                throw fostlib::exceptions::parse_error{"Could not parse row", *pos};
+                throw fostlib::exceptions::parse_error{"Could not parse row",
+                                                       *pos};
             }
         }
     }
@@ -73,7 +74,8 @@ fostlib::csj::parser::const_iterator &
         while (pos != owner.li_end) {
             parseline(owner.line_p, ++pos, owner.li_end, line);
             if (line.size()) {
-                throw exceptions::parse_error{"Empty line embedded in CSJ file"};
+                throw exceptions::parse_error{
+                        "Empty line embedded in CSJ file"};
             }
         }
     } else if (line.size() != owner.header().size()) {

--- a/Cpp/fostgres-fg/fg.testserver.cpp
+++ b/Cpp/fostgres-fg/fg.testserver.cpp
@@ -55,8 +55,10 @@ namespace {
         } catch (fostlib::exceptions::parse_error &e) {
             if (expected_status == 400) {
                 auto response = boost::make_shared<fostlib::text_body>(
-                fostlib::string{"<html><head><title>Parse error</title></head><body><h1>Parse error</h1></body></html>"},
-                fostlib::mime::mime_headers(), "text/html");
+                        fostlib::string{"<html><head><title>Parse "
+                                        "error</title></head><body><h1>Parse "
+                                        "error</h1></body></html>"},
+                        fostlib::mime::mime_headers(), "text/html");
                 return {response, 400};
             } else {
                 fostlib::insert(e.data(), "request", "headers", req.headers());

--- a/Cpp/fostgres/file.cpp
+++ b/Cpp/fostgres/file.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2017-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2017-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -13,10 +13,7 @@
 
 
 fostlib::nullable<fostlib::json> fostgres::file_upload(
-        const fostlib::string &name,
-        const fostlib::json &defn,
-        const fostlib::json &row) {
-    fostlib::json representation;
+        f5::u8view name, fostlib::json const &defn, fostlib::json const &row) {
     if (defn["source"].isnull() && row.has_key(name)) {
         fostlib::base64_string value{
                 fostlib::coerce<fostlib::string>(row[name])};
@@ -39,7 +36,7 @@ fostlib::nullable<fostlib::json> fostgres::file_upload(
         location /= filename;
         fostlib::fs::ofstream save(location);
         save.write(reinterpret_cast<const char *>(data.data()), data.size());
-        return fostlib::json((directory / filename).c_str());
+        return fostlib::coerce<fostlib::json>(directory / filename);
     } else {
         throw fostlib::exceptions::not_implemented(
                 __PRETTY_FUNCTION__, "File upload where `source` is specified");

--- a/Cpp/fostgres/fostgres-control-error.cpp
+++ b/Cpp/fostgres/fostgres-control-error.cpp
@@ -27,18 +27,18 @@ namespace {
                 const fostlib::host &host) const {
             try {
                 if (not config.has_key("execute")) {
-                    throw fostlib::exceptions::not_implemented(
-                            __PRETTY_FUNCTION__, "Missing execute key");
+                    throw fostlib::exceptions::not_implemented{
+                            __PRETTY_FUNCTION__, "Missing execute key"};
                 }
                 return execute(config["execute"], path, req, host);
             } catch (pqxx::sql_error const &e) {
-                if (config.has_key(e.sqlstate().c_str())) {
-                    return execute(
-                            config[e.sqlstate().c_str()], path, req, host);
+                f5::u8string sqlstate{e.sqlstate()};
+                if (config.has_key(sqlstate)) {
+                    return execute(config[sqlstate], path, req, host);
                 } else {
                     return execute(config[""], path, req, host);
                 }
-            } catch (pqxx::failure const &e) {
+            } catch (pqxx::failure const &) {
                 return execute(config[""], path, req, host);
             }
         }

--- a/Cpp/include/fostgres/response.hpp
+++ b/Cpp/include/fostgres/response.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2016-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2016-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -35,9 +35,9 @@ namespace fostgres {
 
     /// Process a file upload datum and return the file name
     fostlib::nullable<fostlib::json> file_upload(
-            const fostlib::string &name,
-            const fostlib::json &defn,
-            const fostlib::json &row);
+            f5::u8view name,
+            fostlib::json const &defn,
+            fostlib::json const &row);
 
 
     struct match;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ if(TARGET stress OR TARGET pgtest)
                 fostgres-test
                 films/view.film-slug.json
                 films/films.csj
+                films/films.edit.broken.csj
                 films/films.edit.csj
                 films/films.fg
         )

--- a/test/films/films.edit.broken.csj
+++ b/test/films/films.edit.broken.csj
@@ -1,0 +1,2 @@
+"slug","title"
+"t2","Terminator 2:

--- a/test/films/films.fg
+++ b/test/films/films.fg
@@ -30,3 +30,6 @@ GET film.slug.error.missing.execute /iawl 501
 ## Once the films are in the database, we can now edit them without needing
 ## all of the fields specified.
 PATCH film.slug / (module.path.join films.edit.csj) 200 {"records": 3}
+
+## Broken CSJ leads to a 400 error
+PATCH film.slug / (module.path.join films.edit.broken.csj) 400


### PR DESCRIPTION
Improves the error thrown for CSJ parse error and also allows parse errors to be tested by expecting a 400 response.